### PR TITLE
couchbase-java-sdk patch

### DIFF
--- a/blackduck/couchbase-sdk-java/get_source.sh
+++ b/blackduck/couchbase-sdk-java/get_source.sh
@@ -30,8 +30,6 @@ fi
 rm -rf *-fit-performer
 
 make deps-only
-# test-utils is in Makefile now and this line can be removed when we don't need to build older versions
-./mvnw -B -DskipTests install -pl test-utils -am
 
 # And now we actually need to build stuff for it to be found
 # by the detector


### PR DESCRIPTION
The main fix is to add compile so that all modules are built before dependency resolution is attempted.  This allows the script to work with SDKs that aren't yet published to Maven Central.

Also switching to ./mvnw as it may be required to use recent Maven plugins.

And the script's current error flow is confusing: it tries dependency resolution, and if that fails then it installs all dependencies (basically what the Makefile does) and then.. stops.  Maybe for the next run to pickup.

Replaced that with just installing the dependencies upfront.